### PR TITLE
If form was not found, try again using a looser CSS selector

### DIFF
--- a/view/frontend/web/js/model/checkout/order-comment-validator.js
+++ b/view/frontend/web/js/model/checkout/order-comment-validator.js
@@ -23,6 +23,11 @@ define(
                 var isCustomer = customer.isLoggedIn();
                 var form = $('.payment-method input[name="payment[method]"]:checked').parents('.payment-method').find('form.order-comment-form');
 
+                // Compatibility for Rubic_CleanCheckout
+                if (!form.length) {
+                    form = $('form.order-comment-form');
+                }
+
                 var comment = form.find('.input-text.order-comment').val();
                 if (this.hasMaxLength() && comment.length > this.getMaxLength()) {
                     messageContainer.addErrorMessage({ message: __("Comment is too long") });


### PR DESCRIPTION
Compatibility for Rubic_CleanCheckout. The order comment wasn't passed because the form wasn't found in the checkout.