### PR TITLE
Fix invoice comment

### DIFF
--- a/Plugin/Block/Adminhtml/SalesOrderViewInfo.php
+++ b/Plugin/Block/Adminhtml/SalesOrderViewInfo.php
@@ -15,7 +15,7 @@ class SalesOrderViewInfo
         \Magento\Sales\Block\Adminhtml\Order\View\Info $subject,
         $result
     ) {
-        $commentBlock = $subject->getLayout()->getBlock('order_comments');
+        $commentBlock = $subject->getLayout()->getBlock('boldcommerce_order_comments');
         if ($commentBlock !== false && $subject->getNameInLayout() == 'order_info') {
             $commentBlock->setOrderComment($subject->getOrder()->getData(OrderComment::COMMENT_FIELD_NAME));
             $result = $result . $commentBlock->toHtml();

--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Backend\Block\Template" name="order_comments" template="Bold_OrderComment::order/view/comments.phtml" />
+        <block class="Magento\Backend\Block\Template" name="boldcommerce_order_comments" template="Bold_OrderComment::order/view/comments.phtml" />
     </body>
 </page>


### PR DESCRIPTION
On the invoice page, the comment field is displayed 2 times. When an invoice comment is added, it is added 2 times.
This pull request fixed this by renaming the order comments block from "order_comments" to "boldcommerce_order_comments"
![boldecommerce_ordercomment_invoice](https://user-images.githubusercontent.com/1506882/51018606-7d107480-1578-11e9-8d64-57e27c6f9b13.png)
