### PR TITLE
Add php 7.4 for magento 2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Module to add  a comment field above the place order button in the checkout",
   "version": "1.6.4",
   "require": {
-    "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0"
+    "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0"
   },
   "type": "magento2-module",
   "keywords": ["magento2"],


### PR DESCRIPTION
php 7.4 is suggested for magento 2.4.0