### PR TITLE
Adding the column as a field on Magento order information endpoint

### DIFF
--- a/CustomBoldCommentPlugin
+++ b/CustomBoldCommentPlugin
@@ -1,0 +1,41 @@
+<?php
+namespace Bold\OrderComment\Plugin;
+use Magento\Sales\Api\Data\OrderExtensionFactory;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderSearchResultInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
+class CustomBoldCommentPlugin
+{
+
+    const FIELD_NAME = 'bold_order_comment';
+    protected $extensionFactory;
+
+    public function __construct(OrderExtensionFactory $extensionFactory)
+    {
+        $this->extensionFactory = $extensionFactory;
+    }
+
+    public function afterGet(OrderRepositoryInterface $subject, OrderInterface $order)
+    {
+        $customBoldComments = $order->getData(self::FIELD_NAME);
+        $extensionAttributes = $order->getExtensionAttributes();
+        $extensionAttributes = $extensionAttributes ? $extensionAttributes : $this->extensionFactory->create();
+        $extensionAttributes->setBoldOrderComment($customBoldComments);
+        $order->setExtensionAttributes($extensionAttributes);
+        return $order;
+    }
+
+    public function afterGetList(OrderRepositoryInterface $subject, OrderSearchResultInterface $searchResult)
+    {
+        $orders = $searchResult->getItems();
+        foreach ($orders as &$order) {
+            $customBoldComments = $order->getData(self::FIELD_NAME);
+            $extensionAttributes = $order->getExtensionAttributes();
+            $extensionAttributes = $extensionAttributes ? $extensionAttributes : $this->extensionFactory->create();
+            $extensionAttributes->setBoldOrderComment($customBoldComments);
+            $order->setExtensionAttributes($extensionAttributes);
+        }
+        return $searchResult;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -15,4 +15,9 @@
     <type name="Magento\Sales\Api\OrderRepositoryInterface">
         <plugin name="bold_load_ordercomment" type="Bold\OrderComment\Plugin\Model\Order\LoadOrderComment"/>
     </type>
+    
+    <type name="Magento\Sales\Api\OrderRepositoryInterface">
+        <plugin name="bold_order_comment_add_order_extension_attribute"
+                type="Bold\OrderComment\Plugin\CustomBoldCommentPlugin" />
+    </type>
 </config>

--- a/i18n/es_ES.csv
+++ b/i18n/es_ES.csv
@@ -1,0 +1,5 @@
+"Do you have any comments regarding the order?","¿Tienes algún comentario para agregar al pedido?"
+"Enter your comment...","Ingrese su comentario..."
+"Order Comment","Comentario del pedido"
+"The order comment could not be saved","El comentario del pedido no pudo ser almacenado"
+"Cart %1 doesn't contain products","El carrito %1 no contiene productos"


### PR DESCRIPTION
This column will be available on Magento order information endpoint. ( /rest/V1/orders/{order-id} )