### PR TITLE
fix: warning with PHP 8.1: Deprecated function: trim()

### DIFF
--- a/Block/Order/Comment.php
+++ b/Block/Order/Comment.php
@@ -34,7 +34,7 @@ class Comment extends \Magento\Framework\View\Element\Template
 
     public function getOrderComment(): string
     {
-        return trim($this->getOrder()->getData(OrderComment::COMMENT_FIELD_NAME));
+        return trim((string) $this->getOrder()->getData(OrderComment::COMMENT_FIELD_NAME));
     }
 
     public function hasOrderComment() : bool


### PR DESCRIPTION
Using Magento 2.4.4
and 
PHP version 8.1.8

The module is currently throwing an error in the checkout process when the field is empty.

Reference : https://github.com/boldcommerce/magento2-ordercomments/pull/71#issuecomment-1206662857