### PR TITLE
allow composer installation with php 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "boldcommerce/magento2-ordercomments",
   "description": "Magento 2 Module to add  a comment field above the place order button in the checkout",
   "require": {
-    "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0"
+    "php": "^7.0.0|^8.0.0"
   },
   "type": "magento2-module",
   "keywords": ["magento2"],


### PR DESCRIPTION
This pull request is intended to make it possible to install the extension with Magento 2.4.6 and PHP 8.2, I did not test the actual compatibility of the module with PHP 8.2.